### PR TITLE
Update setup script to use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 
-from distutils.core import setup
+from setuptools import setup
 
-setup(name='nbp',
-      version='0.1.0',
-      description='N-Body Physics Simulator',
-      author='Stephan Meijer',
-      author_email='me@stephanmeijer.com',
-      url='https://github.com/N-BodyPhysicsSimulator/Main',
-      license='GPL-3.0',
-      packages=['nbp']
-     )
+setup(
+    name='nbp',
+    version='0.1.0',
+    description='N-Body Physics Simulator',
+    author='Stephan Meijer',
+    author_email='me@stephanmeijer.com',
+    url='https://github.com/N-BodyPhysicsSimulator/Main',
+    license='GPL-3.0',
+    packages=['nbp'],
+    install_requires=[
+        'numpy',
+        'websockets'
+    ],
+)


### PR DESCRIPTION
## Summary
- switch to `setuptools` for packaging
- add runtime dependencies `numpy` and `websockets`

## Testing
- `python3 -m pip install .`
- `python3 -m pytest -q` *(fails: DocTestFailure)*

------
https://chatgpt.com/codex/tasks/task_e_68420066844883218fef284fde7468cf