### PR TITLE
Fix README WebSocket server typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You could run `python3 -m nbp --inputprovider json -o ws -dt 10`
 nbp: error: the following arguments are required: --input-file, --ws-port
 ```
 
-The `json` Input Provider requires parameter `--input-file` with a path to the JSON file and the `ws` Output Writer requires `--ws-port` with a port for the WebSocket server to 1listen on.
+The `json` Input Provider requires parameter `--input-file` with a path to the JSON file and the `ws` Output Writer requires `--ws-port` with a port for the WebSocket server to listen on.
 
 Let's run `python3 -m nbp --inputprovider json -o ws -dt 10 --input-file /home/<user>/input.json --ws-port 8080`
 


### PR DESCRIPTION
## Summary
- fix a typo in README about WebSocket server usage

## Testing
- `make test` *(fails: python3.5 not found)*
- `python3 -m pytest -vv nbp tests` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68428d1c55ec83218378d426205093a2