### PR TITLE
Remove python3.5 references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: "3.5.2"
+python: "3.12"
 before_install:
 install: make install-requirements 
 script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PY=python3.5
+PY=python3
 files=nbp/**/*.py
 module=nbp
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ interface is provided for running experiments.
 
 ## How to run from source
 
-For running the simulator, Python `3.5.x` or higher is required.
+For running the simulator, Python `3.8` or higher is required.
 
 Not tested on `Mac OS X`/`macOS` or `Microsoft Windows`.
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 from nbp import Cli
 
 def test_required_arguments(capsys):
-    argv = "python3.5 nbp_cli.py".split(" ")
+    argv = "python3 nbp_cli.py".split(" ")
 
     with pytest.raises(SystemExit):
         Cli(argv).start_application()
@@ -18,7 +18,7 @@ def test_required_arguments(capsys):
     assert "--outputwriter/-o" in err
 
 def test_forbid_max_ticks_with_max_time(capsys):
-    argv = "python3.5 nbp_cli.py -i json -o json -dt 1 --max-ticks 1 --max-time 1".split(" ")
+    argv = "python3 nbp_cli.py -i json -o json -dt 1 --max-ticks 1 --max-time 1".split(" ")
 
     with pytest.raises(SystemExit):
         Cli(argv).start_application()

--- a/tests/integration_tests/test_greater_than.py
+++ b/tests/integration_tests/test_greater_than.py
@@ -27,62 +27,62 @@ def greater_than_zero_should_pass(capsys, command, parameter):
 def test_delta_time_greater_than_zero(capsys):
     greater_than_zero(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 0",
+        "python3 nbp_cli.py -i json -o json -dt 0",
         "--delta-time/-dt"
     )
 
 def test_max_ticks_greater_than_zero(capsys):
     greater_than_zero(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1 --max-ticks 0",
+        "python3 nbp_cli.py -i json -o json -dt 1 --max-ticks 0",
         "--max-ticks/-t"
     )
 
 def test_max_time_greater_than_zero(capsys):
     greater_than_zero(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1 --max-time 0",
+        "python3 nbp_cli.py -i json -o json -dt 1 --max-time 0",
         "--max-time/-T"
     )
 
 def test_delta_time_not_negative(capsys):
     greater_than_zero(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt -1",
+        "python3 nbp_cli.py -i json -o json -dt -1",
         "--delta-time/-dt"
     )
 
 def test_max_ticks_not_negative(capsys):
     greater_than_zero(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1 --max-ticks -1",
+        "python3 nbp_cli.py -i json -o json -dt 1 --max-ticks -1",
         "--max-ticks/-t"
     )
 
 def test_max_time_not_negative(capsys):
     greater_than_zero(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1 --max-time -1",
+        "python3 nbp_cli.py -i json -o json -dt 1 --max-time -1",
         "--max-time/-T"
     )
 
 def test_delta_time_positive(capsys):
     greater_than_zero_should_pass(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1",
+        "python3 nbp_cli.py -i json -o json -dt 1",
         "--delta-time/-dt"
     )
 
 def test_max_ticks_positive(capsys):
     greater_than_zero_should_pass(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1 --max-ticks 1",
+        "python3 nbp_cli.py -i json -o json -dt 1 --max-ticks 1",
         "--max-ticks/-t"
     )
 
 def test_max_time_positive(capsys):
     greater_than_zero_should_pass(
         capsys,
-        "python3.5 nbp_cli.py -i json -o json -dt 1 --max-time 1",
+        "python3 nbp_cli.py -i json -o json -dt 1 --max-time 1",
         "--max-time/-T"
     )


### PR DESCRIPTION
## Summary
- drop explicit Python 3.5 usage in Makefile and tests
- adjust supported Python version in README
- update Travis CI to a modern Python

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429d8e74708321bf58ad3bcd1b8f1d